### PR TITLE
2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.flrp</groupId>
     <artifactId>economobs</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
     <packaging>jar</packaging>
 
     <name>Economobs</name>

--- a/src/main/java/dev/flrp/economobs/Economobs.java
+++ b/src/main/java/dev/flrp/economobs/Economobs.java
@@ -39,6 +39,7 @@ import dev.triumphteam.cmd.core.message.MessageKey;
 public final class Economobs extends JavaPlugin {
 
     private static Economobs instance;
+    private Metrics metrics;
 
     private Configuration config;
     private Configuration mobs;
@@ -64,16 +65,20 @@ public final class Economobs extends JavaPlugin {
         Locale.log("&aStarting...");
 
         // bStats
-        new Metrics(this, 12086);
+        metrics = new Metrics(this, 12086);
 
         // Files
         initiateFiles();
         Locale.load();
 
+        initiateClasses();
+
         // Modules
         Injector hookInjector = Guice.createInjector(new EconomyModule(this), new StackerModule(this), new EntityModule(this), new ItemModule(this), new HologramModule(this));
         hookManager = hookInjector.getInstance(HookManager.class);
         hookManager.getStackerProvider().registerEvents();
+
+        messageManager.resolveHologramProvider();
 
         // Update Checker
         new UpdateChecker(this, 90004).checkForUpdate(version -> {
@@ -84,9 +89,6 @@ public final class Economobs extends JavaPlugin {
                 Locale.log("&8--------------");
             }
         });
-
-        // Initiation
-        initiateClasses();
 
         // Hooks
         File dir = new File(getDataFolder(), "hooks");
@@ -122,6 +124,9 @@ public final class Economobs extends JavaPlugin {
         initiateFiles();
         Locale.load();
 
+        // Classes
+        initiateClasses();
+
         // Modules
         for (EntityProvider entityProvider : hookManager.getEntityProviders()) {
             if (entityProvider instanceof Builder builder) {
@@ -134,10 +139,9 @@ public final class Economobs extends JavaPlugin {
             }
         }
 
-        hookManager.getStackerProvider().registerEvents();
+        messageManager.resolveHologramProvider();
 
-        // Initiation
-        initiateClasses();
+        hookManager.getStackerProvider().registerEvents();
 
         Locale.log("&aDone!");
 

--- a/src/main/java/dev/flrp/economobs/manager/MessageManager.java
+++ b/src/main/java/dev/flrp/economobs/manager/MessageManager.java
@@ -35,14 +35,6 @@ public class MessageManager {
         switch (messageType) {
             case HOLOGRAM:
                 hologramSetting = new HologramSetting(plugin);
-                if (!(plugin.getHookManager().getHologramProvider() instanceof NoopHologramProvider)) {
-                    hologramSetting.setHologramProvider(plugin.getHookManager().getHologramProvider());
-                    hologramSetting.setDuration(plugin.getConfig().getInt("message.holograms.duration", 1) * 20);
-                } else {
-                    Locale.log("No valid hologram provider found. Defaulting to CHAT messages.");
-                    messageType = MessageType.CHAT;
-                    hologramSetting = null;
-                }
                 break;
             case TITLE:
                 titleSetting = new TitleSetting();
@@ -54,6 +46,18 @@ public class MessageManager {
                 break;
             default:
                 break;
+        }
+    }
+
+    public void resolveHologramProvider() {
+        if (messageType != MessageType.HOLOGRAM) return;
+        if (!(plugin.getHookManager().getHologramProvider() instanceof NoopHologramProvider)) {
+            hologramSetting.setHologramProvider(plugin.getHookManager().getHologramProvider());
+            hologramSetting.setDuration(plugin.getConfig().getInt("message.holograms.duration", 1) * 20);
+        } else {
+            Locale.log("No valid hologram provider found. Defaulting to CHAT messages.");
+            messageType = MessageType.CHAT;
+            hologramSetting = null;
         }
     }
 


### PR DESCRIPTION
Adds a fix for a plugin crash that happens when a valid hook loads before a dependency. It resolves the hologram provider after all hooks and necessary classes have loaded. This also assigns bStats metrics to a variable so it can stay alive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of hologram messages by resolving the provider earlier in startup and reload flows.
  - Enhanced reload stability by initializing components sooner and re-registering related events consistently.
  - Prevented stale data after reload by refreshing the database at the end of the process.

- Chores
  - Version bumped to 2.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->